### PR TITLE
Refactorings of QueenAttack tests

### DIFF
--- a/exercises/queen-attack/queen_attack_test.rb
+++ b/exercises/queen-attack/queen_attack_test.rb
@@ -23,20 +23,20 @@ class QueensTest < Minitest::Test
 
   def test_queens_must_have_a_positive_rank
     skip
-    assert_raises ArgumentError { Queens.new(white: [-1, 4], black: [ 2, 4]) }
-    assert_raises ArgumentError { Queens.new(white: [ 2, 4], black: [-1, 4]) }
+    assert_raises ArgumentError { Queens.new(white: [-1, 4], black: [2, 4]) }
+    assert_raises ArgumentError { Queens.new(white: [2, 4], black: [-1, 4]) }
   end
 
   def test_queens_must_have_a_positive_file
     skip
-    assert_raises ArgumentError { Queens.new(white: [4, -1], black: [4,  2]) }
-    assert_raises ArgumentError { Queens.new(white: [4,  2], black: [4, -1]) }
+    assert_raises ArgumentError { Queens.new(white: [4, -1], black: [4, 2]) }
+    assert_raises ArgumentError { Queens.new(white: [4, 2], black: [4, -1]) }
   end
 
   def test_queen_ranks_do_not_exceed_board_size
     skip
-    assert_raises ArgumentError { Queens.new(white: [ 8, 4], black: [ 2, 4]) }
-    assert_raises ArgumentError { Queens.new(white: [ 2, 4], black: [ 8, 4]) }
+    assert_raises ArgumentError { Queens.new(white: [8, 4], black: [2, 4]) }
+    assert_raises ArgumentError { Queens.new(white: [2, 4], black: [8, 4]) }
   end
 
   def test_queen_files_do_not_exceed_board_size

--- a/exercises/queen-attack/queen_attack_test.rb
+++ b/exercises/queen-attack/queen_attack_test.rb
@@ -27,6 +27,13 @@ class QueensTest < Minitest::Test
       Queens.new(white: [2, 4], black: [2, 4])
     end
   end
+  
+  def test_rank_and_file_use_0_based_indexing
+    skip
+    queens = Queens.new(white: [0, 0], black: [0, 1])  
+    assert_equal [0, 0], queens.white
+    assert_equal [0, 1], queens.black
+  end
 
   def test_string_representation # rubocop:disable Metrics/MethodLength
     skip

--- a/exercises/queen-attack/queen_attack_test.rb
+++ b/exercises/queen-attack/queen_attack_test.rb
@@ -23,31 +23,31 @@ class QueensTest < Minitest::Test
 
   def test_queens_must_have_a_positive_rank
     skip
-    assert_raises ArgumentError { Queens.new(white: [-1, 4], black: [2, 4]) }
-    assert_raises ArgumentError { Queens.new(white: [2, 4], black: [-1, 4]) }
+    assert_raises(ArgumentError) { Queens.new(white: [-1, 4], black: [2, 4]) }
+    assert_raises(ArgumentError) { Queens.new(white: [2, 4], black: [-1, 4]) }
   end
 
   def test_queens_must_have_a_positive_file
     skip
-    assert_raises ArgumentError { Queens.new(white: [4, -1], black: [4, 2]) }
-    assert_raises ArgumentError { Queens.new(white: [4, 2], black: [4, -1]) }
+    assert_raises(ArgumentError) { Queens.new(white: [4, -1], black: [4, 2]) }
+    assert_raises(ArgumentError) { Queens.new(white: [4, 2], black: [4, -1]) }
   end
 
   def test_queen_ranks_do_not_exceed_board_size
     skip
-    assert_raises ArgumentError { Queens.new(white: [8, 4], black: [2, 4]) }
-    assert_raises ArgumentError { Queens.new(white: [2, 4], black: [8, 4]) }
+    assert_raises(ArgumentError) { Queens.new(white: [8, 4], black: [2, 4]) }
+    assert_raises(ArgumentError) { Queens.new(white: [2, 4], black: [8, 4]) }
   end
 
   def test_queen_files_do_not_exceed_board_size
     skip
-    assert_raises ArgumentError { Queens.new(white: [2, 8], black: [2, 4]) }
-    assert_raises ArgumentError { Queens.new(white: [2, 4], black: [2, 8]) }
+    assert_raises(ArgumentError) { Queens.new(white: [2, 8], black: [2, 4]) }
+    assert_raises(ArgumentError) { Queens.new(white: [2, 4], black: [2, 8]) }
   end
 
   def test_cannot_occupy_same_space
     skip
-    assert_raises ArgumentError { Queens.new(white: [2, 4], black: [2, 4]) }
+    assert_raises(ArgumentError) { Queens.new(white: [2, 4], black: [2, 4]) }
   end
 
   def test_string_representation # rubocop:disable Metrics/MethodLength

--- a/exercises/queen-attack/queen_attack_test.rb
+++ b/exercises/queen-attack/queen_attack_test.rb
@@ -33,13 +33,13 @@ class QueensTest < Minitest::Test
     assert_raises ArgumentError { Queens.new(white: [4,  2], black: [4, -1]) }
   end
 
-  def test_queen_rank_does_not_exceed_board_size
+  def test_queen_ranks_do_not_exceed_board_size
     skip
     assert_raises ArgumentError { Queens.new(white: [ 8, 4], black: [ 2, 4]) }
     assert_raises ArgumentError { Queens.new(white: [ 2, 4], black: [ 8, 4]) }
   end
 
-  def test_queen_file_does_not_exceed_board_size
+  def test_queen_files_do_not_exceed_board_size
     skip
     assert_raises ArgumentError { Queens.new(white: [2, 8], black: [2, 4]) }
     assert_raises ArgumentError { Queens.new(white: [2, 4], black: [2, 8]) }

--- a/exercises/queen-attack/queen_attack_test.rb
+++ b/exercises/queen-attack/queen_attack_test.rb
@@ -4,12 +4,6 @@ require 'minitest/autorun'
 require_relative 'queen_attack'
 
 class QueensTest < Minitest::Test
-  def test_default_positions
-    queens = Queens.new
-    assert_equal [0, 3], queens.white
-    assert_equal [7, 3], queens.black
-  end
-
   def test_specific_placement
     skip
     queens = Queens.new(white: [3, 7], black: [6, 1])

--- a/exercises/queen-attack/queen_attack_test.rb
+++ b/exercises/queen-attack/queen_attack_test.rb
@@ -21,20 +21,6 @@ class QueensTest < Minitest::Test
     assert_equal [7, 7], queens2.black
   end
 
-  def test_cannot_occupy_same_space
-    skip
-    assert_raises ArgumentError do
-      Queens.new(white: [2, 4], black: [2, 4])
-    end
-  end
-
-  def test_rank_and_file_use_0_based_indexing
-    skip
-    queens = Queens.new(white: [0, 0], black: [0, 1])  
-    assert_equal [0, 0], queens.white
-    assert_equal [0, 1], queens.black
-  end
-
   def test_queens_must_have_a_positive_rank
     skip
     assert_raises ArgumentError { Queens.new(white: [-1, 4], black: [ 2, 4]) }
@@ -57,6 +43,11 @@ class QueensTest < Minitest::Test
     skip
     assert_raises ArgumentError { Queens.new(white: [2, 8], black: [2, 4]) }
     assert_raises ArgumentError { Queens.new(white: [2, 4], black: [2, 8]) }
+  end
+
+  def test_cannot_occupy_same_space
+    skip
+    assert_raises ArgumentError { Queens.new(white: [2, 4], black: [2, 4]) }
   end
 
   def test_string_representation # rubocop:disable Metrics/MethodLength
@@ -149,5 +140,26 @@ _ _ _ _ _ _ _ _
     skip
     queens = Queens.new(white: [6, 1], black: [1, 6])
     assert queens.attack?
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module.
+  #  In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 1, BookKeeping::VERSION
   end
 end

--- a/exercises/queen-attack/queen_attack_test.rb
+++ b/exercises/queen-attack/queen_attack_test.rb
@@ -27,12 +27,36 @@ class QueensTest < Minitest::Test
       Queens.new(white: [2, 4], black: [2, 4])
     end
   end
-  
+
   def test_rank_and_file_use_0_based_indexing
     skip
     queens = Queens.new(white: [0, 0], black: [0, 1])  
     assert_equal [0, 0], queens.white
     assert_equal [0, 1], queens.black
+  end
+
+  def test_queens_must_have_a_positive_rank
+    skip
+    assert_raises ArgumentError { Queens.new(white: [-1, 4], black: [ 2, 4]) }
+    assert_raises ArgumentError { Queens.new(white: [ 2, 4], black: [-1, 4]) }
+  end
+
+  def test_queens_must_have_a_positive_file
+    skip
+    assert_raises ArgumentError { Queens.new(white: [4, -1], black: [4,  2]) }
+    assert_raises ArgumentError { Queens.new(white: [4,  2], black: [4, -1]) }
+  end
+
+  def test_queen_rank_does_not_exceed_board_size
+    skip
+    assert_raises ArgumentError { Queens.new(white: [ 8, 4], black: [ 2, 4]) }
+    assert_raises ArgumentError { Queens.new(white: [ 2, 4], black: [ 8, 4]) }
+  end
+
+  def test_queen_file_does_not_exceed_board_size
+    skip
+    assert_raises ArgumentError { Queens.new(white: [2, 8], black: [2, 4]) }
+    assert_raises ArgumentError { Queens.new(white: [2, 4], black: [2, 8]) }
   end
 
   def test_string_representation # rubocop:disable Metrics/MethodLength


### PR DESCRIPTION
Removed test for default position (made no sense and is not in the x-common tests).

Added tests to ensure that queens are placed on the board.

Changed a test to use in-line blocks for consistency with the other tests.

Added a version constant test.
